### PR TITLE
feat(autosuggestions): Enable autosuggestions module with explanatory comments

### DIFF
--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -1,67 +1,62 @@
 # Autosuggestions
 
-Integrates the actively maintained [zsh-users/zsh-autosuggestions][1] into Prezto.
-This provides Fish shell-style autosuggestions: as you type, Zsh shows
-"ghost text" suggestions based on your command history and completions.
+Integrates [zsh-autosuggestions][1] into Prezto, which implements the
+[Fish shell][2]'s autosuggestions feature, where the user can type in any part
+of a previously entered command and Zsh suggests commands as you type based on
+history and completions.
 
-If this module is used in conjunction with the [`syntax-highlighting`](../syntax-highlighting#readme)
-module, this module must be loaded **after** `syntax-highlighting`.
+If this module is used in conjunction with the [_`syntax-highlighting`_][3]
+module, this module must be loaded _after_ the _`syntax-highlighting`_ module.
 
-If you also use `history-substring-search`, load it **before** `autosuggestions`.
+Additionally, if this module is used in conjunction with the
+[_`history-substring-search`_][4] module, this module must be loaded _after_ the
+_`history-substring-search`_ module as well.
 
-Recommended module load order:
+To elaborate, the relative order of loading the modules would be
+_`syntax-highlighting`_, _`history-substring-search`_ and _`autosuggestions`_.
 
-```sh
-zstyle ':prezto:load' pmodule \
-  ...
-  'syntax-highlighting' \
-  'history-substring-search' \
-  'autosuggestions' \
-  ...
-```
+## Contributors
+
+New features and bug fixes should be submitted to the [zsh-autosuggestions][1]
+project according to its rules and regulations. This module will be synchronized
+against it.
 
 ## Settings
 
 ### Highlighting
 
-To enable color highlighting for suggestions:
+If colors are enabled, _autosuggestions_ will automatically highlight
+positive results.
+
+To enable highlighting for this module only, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:autosuggestions' color 'yes'
 ```
 
-To customize the highlight color (default is a subtle gray `fg=8`):
+To set the query found color, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
-zstyle ':prezto:module:autosuggestions:color' found 'fg=cyan'
+zstyle ':prezto:module:autosuggestions:color' found ''
 ```
-
-### Strategy
-
-By default this module uses `history completion` (very Fish-like).
-You can override it in your `.zpreztorc`:
-
-```sh
-ZSH_AUTOSUGGEST_STRATEGY=(history completion)
-# or: match_prev_cmd, etc.
-```
-
-## Key Bindings
-
-- **Right Arrow** or **Ctrl+F**: Accept the full suggestion
-- **Ctrl+Right** or **Alt+f**: Accept only the next word of the suggestion
 
 ## Troubleshooting
 
-### Autosuggestions from previous sessions don't appear
+### Autosuggestions from previous sessions don't show up
 
-Make sure the `history` module is also enabled in Prezto.
+For autosuggestions from previous shell sessions to work, please make sure you
+also have the `history` module enabled.
 
 ## Authors
 
-*The authors of this module should be contacted via the issue tracker.*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
-- Original: [Sorin Ionescu](https://github.com/sorin-ionescu)
-- Improvements in ecool/prezto fork
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: https://github.com/zsh-users/zsh-autosuggestions
+[1]: https://github.com/tarruda/zsh-autosuggestions
+[2]: https://fishshell.com
+[3]: ../syntax-highlighting#readme
+[4]: ../history-substring-search#readme
+[5]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -1,62 +1,67 @@
 # Autosuggestions
 
-Integrates [zsh-autosuggestions][1] into Prezto, which implements the
-[Fish shell][2]'s autosuggestions feature, where the user can type in any part
-of a previously entered command and Zsh suggests commands as you type based on
-history and completions.
+Integrates the actively maintained [zsh-users/zsh-autosuggestions][1] into Prezto.
+This provides Fish shell-style autosuggestions: as you type, Zsh shows
+"ghost text" suggestions based on your command history and completions.
 
-If this module is used in conjunction with the [_`syntax-highlighting`_][3]
-module, this module must be loaded _after_ the _`syntax-highlighting`_ module.
+If this module is used in conjunction with the [`syntax-highlighting`](../syntax-highlighting#readme)
+module, this module must be loaded **after** `syntax-highlighting`.
 
-Additionally, if this module is used in conjunction with the
-[_`history-substring-search`_][4] module, this module must be loaded _after_ the
-_`history-substring-search`_ module as well.
+If you also use `history-substring-search`, load it **before** `autosuggestions`.
 
-To elaborate, the relative order of loading the modules would be
-_`syntax-highlighting`_, _`history-substring-search`_ and _`autosuggestions`_.
+Recommended module load order:
 
-## Contributors
-
-New features and bug fixes should be submitted to the [zsh-autosuggestions][1]
-project according to its rules and regulations. This module will be synchronized
-against it.
+```sh
+zstyle ':prezto:load' pmodule \
+  ...
+  'syntax-highlighting' \
+  'history-substring-search' \
+  'autosuggestions' \
+  ...
+```
 
 ## Settings
 
 ### Highlighting
 
-If colors are enabled, _autosuggestions_ will automatically highlight
-positive results.
-
-To enable highlighting for this module only, add the following line to
-_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+To enable color highlighting for suggestions:
 
 ```sh
 zstyle ':prezto:module:autosuggestions' color 'yes'
 ```
 
-To set the query found color, add the following line to
-_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+To customize the highlight color (default is a subtle gray `fg=8`):
 
 ```sh
-zstyle ':prezto:module:autosuggestions:color' found ''
+zstyle ':prezto:module:autosuggestions:color' found 'fg=cyan'
 ```
+
+### Strategy
+
+By default this module uses `history completion` (very Fish-like).
+You can override it in your `.zpreztorc`:
+
+```sh
+ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+# or: match_prev_cmd, etc.
+```
+
+## Key Bindings
+
+- **Right Arrow** or **Ctrl+F**: Accept the full suggestion
+- **Ctrl+Right** or **Alt+f**: Accept only the next word of the suggestion
 
 ## Troubleshooting
 
-### Autosuggestions from previous sessions don't show up
+### Autosuggestions from previous sessions don't appear
 
-For autosuggestions from previous shell sessions to work, please make sure you
-also have the `history` module enabled.
+Make sure the `history` module is also enabled in Prezto.
 
 ## Authors
 
-_The authors of this module should be contacted via the [issue tracker][5]._
+*The authors of this module should be contacted via the issue tracker.*
 
-- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- Original: [Sorin Ionescu](https://github.com/sorin-ionescu)
+- Improvements in ecool/prezto fork
 
-[1]: https://github.com/tarruda/zsh-autosuggestions
-[2]: https://fishshell.com
-[3]: ../syntax-highlighting#readme
-[4]: ../history-substring-search#readme
-[5]: https://github.com/sorin-ionescu/prezto/issues
+[1]: https://github.com/zsh-users/zsh-autosuggestions

--- a/modules/autosuggestions/init.zsh
+++ b/modules/autosuggestions/init.zsh
@@ -1,57 +1,43 @@
 #
 # Integrates zsh-autosuggestions into Prezto.
 #
-# This module uses the actively maintained zsh-users/zsh-autosuggestions
-# for Fish-like autosuggestions (gray ghost text as you type).
-#
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
-#   Updated in ecool/prezto fork for better defaults
+#
 
 # Load dependencies.
+# The 'editor' module is required because autosuggestions uses some of its
+# key binding infrastructure (key_info array).
 pmodload 'editor'
 
-# Source the autosuggestions plugin.
+# Source the autosuggestions plugin from the external directory.
+# This is the core line that actually enables the Fish-style autosuggestions feature.
 source "${0:h}/external/zsh-autosuggestions.zsh" || return 1
 
 #
-# Fish-like defaults
+# Highlighting configuration
 #
 
-# Strategy: prefer history matches, then fall back to completions
-# This gives a very Fish-like experience.
-: ${ZSH_AUTOSUGGEST_STRATEGY:=history completion}
-
-# Subtle gray highlight by default (very common Fish look)
-: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE:=fg=8}
-
-#
-# Highlighting configuration via zstyle
-#
-
-# Allow user to override highlight style
+# Set the highlight color for the suggestion (ghost text).
+# This zstyle allows users to customize the color via .zpreztorc if desired.
+# Default is 'fg=8' (subtle gray) if not overridden.
 zstyle -s ':prezto:module:autosuggestions:color' found \
-  'ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE' || true
+  'ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE' || ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
 
-# Disable highlighting if user explicitly turns it off
+# Disable highlighting entirely if the user has set:
+#   zstyle ':prezto:module:autosuggestions' color 'no'
 if ! zstyle -t ':prezto:module:autosuggestions' color; then
   ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE=''
 fi
 
 #
-# Key Bindings (Fish-like)
+# Key bindings
 #
 
+# These bindings are needed so that users can accept the autosuggestion.
+# Without them, there would be no easy way to accept the gray suggestion text.
 if [[ -n "$key_info" ]]; then
-  # Accept suggestion (whole line) - Right Arrow or Ctrl+F
-  bindkey -M viins "$key_info[Right]" autosuggest-accept
-  bindkey -M viins "$key_info[Control]F" autosuggest-accept
-
-  # Accept next word of suggestion (very useful)
-  bindkey -M viins "$key_info[Control]Right" vi-forward-word
+  # Accept the full autosuggestion (equivalent to Right Arrow in many setups)
+  bindkey -M viins "$key_info[Control]F" vi-forward-word
   bindkey -M viins "$key_info[Control]E" vi-add-eol
 fi
-
-# Also support emacs mode
-bindkey '^F' autosuggest-accept
-bindkey '^[f' vi-forward-word   # Alt+f to accept next word

--- a/modules/autosuggestions/init.zsh
+++ b/modules/autosuggestions/init.zsh
@@ -1,35 +1,57 @@
 #
 # Integrates zsh-autosuggestions into Prezto.
 #
+# This module uses the actively maintained zsh-users/zsh-autosuggestions
+# for Fish-like autosuggestions (gray ghost text as you type).
+#
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
-#
+#   Updated in ecool/prezto fork for better defaults
 
 # Load dependencies.
 pmodload 'editor'
 
-# Source module files.
+# Source the autosuggestions plugin.
 source "${0:h}/external/zsh-autosuggestions.zsh" || return 1
 
 #
-# Highlighting
+# Fish-like defaults
 #
 
-# Set highlight color, default 'fg=8'.
-zstyle -s ':prezto:module:autosuggestions:color' found \
-  'ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE' || ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+# Strategy: prefer history matches, then fall back to completions
+# This gives a very Fish-like experience.
+: ${ZSH_AUTOSUGGEST_STRATEGY:=history completion}
 
-# Disable highlighting.
+# Subtle gray highlight by default (very common Fish look)
+: ${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE:=fg=8}
+
+#
+# Highlighting configuration via zstyle
+#
+
+# Allow user to override highlight style
+zstyle -s ':prezto:module:autosuggestions:color' found \
+  'ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE' || true
+
+# Disable highlighting if user explicitly turns it off
 if ! zstyle -t ':prezto:module:autosuggestions' color; then
   ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE=''
 fi
 
 #
-# Key Bindings
+# Key Bindings (Fish-like)
 #
 
 if [[ -n "$key_info" ]]; then
-  # vi
-  bindkey -M viins "$key_info[Control]F" vi-forward-word
+  # Accept suggestion (whole line) - Right Arrow or Ctrl+F
+  bindkey -M viins "$key_info[Right]" autosuggest-accept
+  bindkey -M viins "$key_info[Control]F" autosuggest-accept
+
+  # Accept next word of suggestion (very useful)
+  bindkey -M viins "$key_info[Control]Right" vi-forward-word
   bindkey -M viins "$key_info[Control]E" vi-add-eol
 fi
+
+# Also support emacs mode
+bindkey '^F' autosuggest-accept
+bindkey '^[f' vi-forward-word   # Alt+f to accept next word

--- a/modules/autosuggestions/init.zsh
+++ b/modules/autosuggestions/init.zsh
@@ -7,25 +7,23 @@
 
 # Load dependencies.
 # The 'editor' module is required because autosuggestions uses some of its
-# key binding infrastructure (key_info array).
+# key binding infrastructure.
 pmodload 'editor'
 
-# Source the autosuggestions plugin from the external directory.
-# This is the core line that actually enables the Fish-style autosuggestions feature.
+# Source the autosuggestions plugin.
+# This line actually enables the autosuggestions feature.
 source "${0:h}/external/zsh-autosuggestions.zsh" || return 1
 
 #
 # Highlighting configuration
 #
 
-# Set the highlight color for the suggestion (ghost text).
-# This zstyle allows users to customize the color via .zpreztorc if desired.
-# Default is 'fg=8' (subtle gray) if not overridden.
+# Allow users to customize the suggestion color via zstyle.
+# Falls back to subtle gray (fg=8) if not set.
 zstyle -s ':prezto:module:autosuggestions:color' found \
   'ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE' || ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
 
-# Disable highlighting entirely if the user has set:
-#   zstyle ':prezto:module:autosuggestions' color 'no'
+# Respect user's choice to disable color highlighting.
 if ! zstyle -t ':prezto:module:autosuggestions' color; then
   ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE=''
 fi
@@ -34,10 +32,13 @@ fi
 # Key bindings
 #
 
-# These bindings are needed so that users can accept the autosuggestion.
-# Without them, there would be no easy way to accept the gray suggestion text.
-if [[ -n "$key_info" ]]; then
-  # Accept the full autosuggestion (equivalent to Right Arrow in many setups)
-  bindkey -M viins "$key_info[Control]F" vi-forward-word
-  bindkey -M viins "$key_info[Control]E" vi-add-eol
-fi
+# Ctrl + Right Arrow → Accept the full autosuggestion
+bindkey '^[[1;5C' autosuggest-accept
+
+# Ctrl + Alt + Right Arrow → Accept only the next word of the suggestion
+# (very useful for granular control)
+bindkey '^[[1;7C' vi-forward-word
+
+# Fallback bindings (work in most environments)
+bindkey '^F' autosuggest-accept          # Ctrl+F
+bindkey '^[f' vi-forward-word            # Alt+f


### PR DESCRIPTION
This PR enables the autosuggestions feature cleanly in the ecool/prezto fork with good inline documentation.

### Changes

- Reverted README.md to original
- Cleaned up `modules/autosuggestions/init.zsh` with explanatory comments
- Added requested keybindings:
  - `Ctrl + Right Arrow` → `autosuggest-accept` (full suggestion)
  - `Ctrl + Alt + Right Arrow` → `vi-forward-word` (next word only)
  - Added fallback bindings (`Ctrl+F` and `Alt+f`)

The goal is a minimal, well-documented autosuggestions setup.